### PR TITLE
Support manual edits

### DIFF
--- a/chinese_vocab_list.yaml
+++ b/chinese_vocab_list.yaml
@@ -16,10 +16,11 @@
   - I
   - me
   - my
+  - self
   example_sentences:
-  - trad: 我是Tom Hunter。
-    pinyin: wǒ shì Tom   Hunter 。
-    eng: I'm Tom Hunter.
+  - trad: 我是Kerrick Hunter。
+    pinyin: wǒ shì Kerrick   Hunter 。
+    eng: I'm Kerrick Hunter.
 - trad: 你
   pinyin: nǐ
   defs:

--- a/chinese_vocab_list.yaml
+++ b/chinese_vocab_list.yaml
@@ -14,7 +14,7 @@
   pinyin: wǒ
   defs:
   - I
-  - me me me
+  - me
   - my
   - self
   example_sentences:

--- a/chinese_vocab_list.yaml
+++ b/chinese_vocab_list.yaml
@@ -14,7 +14,7 @@
   pinyin: wǒ
   defs:
   - I
-  - me
+  - me me me
   - my
   - self
   example_sentences:

--- a/chinese_vocab_list.yaml
+++ b/chinese_vocab_list.yaml
@@ -29,7 +29,7 @@
   - trad: 我的沒有你的好。
     simp: 我的没有你的好。
     pinyin: wǒ de méiyǒu nǐ de hǎo 。
-    eng: My thing not so good as yours.
+    eng: Mine is not so good as yours.
 - trad: 是
   pinyin: shì
   defs:

--- a/chinese_vocab_list.yaml
+++ b/chinese_vocab_list.yaml
@@ -29,7 +29,7 @@
   - trad: 我的沒有你的好。
     simp: 我的没有你的好。
     pinyin: wǒ de méiyǒu nǐ de hǎo 。
-    eng: Mine is not so good as yours.
+    eng: My thing not so good as yours.
 - trad: 是
   pinyin: shì
   defs:

--- a/chinese_vocab_list.yaml
+++ b/chinese_vocab_list.yaml
@@ -16,11 +16,10 @@
   - I
   - me
   - my
-  - self
   example_sentences:
-  - trad: 我是Kerrick Hunter。
-    pinyin: wǒ shì Kerrick   Hunter 。
-    eng: I'm Kerrick Hunter.
+  - trad: 我是Tom Hunter。
+    pinyin: wǒ shì Tom   Hunter 。
+    eng: I'm Tom Hunter.
 - trad: 你
   pinyin: nǐ
   defs:

--- a/chinesevocablist/__init__.py
+++ b/chinesevocablist/__init__.py
@@ -102,7 +102,7 @@ class VocabList:
   @classmethod
   def load_from_yaml_file(cls, yaml_file_path):
     with open(yaml_file_path, encoding='utf-8') as h:
-      words = [VocabWord.from_dict(d) for d in yaml.load(h)]
+      words = [VocabWord.from_dict(d) for d in yaml.full_load(h)]
       return VocabList(words)
 
   def __init__(self, words):

--- a/chinesevocablist/__init__.py
+++ b/chinesevocablist/__init__.py
@@ -100,6 +100,11 @@ class VocabList:
     return vocab_list_data.vocab_list
 
   @classmethod
+  def load_from_yaml_str(cls, yaml_str):
+    words = [VocabWord.from_dict(d) for d in yaml.full_load(yaml_str)]
+      return VocabList(words)
+
+  @classmethod
   def load_from_yaml_file(cls, yaml_file_path):
     with open(yaml_file_path, encoding='utf-8') as h:
       words = [VocabWord.from_dict(d) for d in yaml.full_load(h)]

--- a/chinesevocablist/__init__.py
+++ b/chinesevocablist/__init__.py
@@ -102,13 +102,13 @@ class VocabList:
   @classmethod
   def load_from_yaml_str(cls, yaml_str):
     words = [VocabWord.from_dict(d) for d in yaml.full_load(yaml_str)]
-      return VocabList(words)
+    return VocabList(words)
 
   @classmethod
   def load_from_yaml_file(cls, yaml_file_path):
     with open(yaml_file_path, encoding='utf-8') as h:
       words = [VocabWord.from_dict(d) for d in yaml.full_load(h)]
-      return VocabList(words)
+    return VocabList(words)
 
   def __init__(self, words):
     self.words = words

--- a/chinesevocablist/__init__.py
+++ b/chinesevocablist/__init__.py
@@ -100,7 +100,7 @@ class VocabList:
     return vocab_list_data.vocab_list
 
   @classmethod
-  def load_from_yaml(cls, yaml_file_path):
+  def load_from_yaml_file(cls, yaml_file_path):
     with open(yaml_file_path, encoding='utf-8') as h:
       words = [VocabWord.from_dict(d) for d in yaml.load(h)]
       return VocabList(words)
@@ -113,7 +113,7 @@ class VocabList:
       self.simp_to_word[word.simp] = word
       self.trad_to_word[word.trad] = word
 
-  def dump_to_yaml(self, yaml_file_path):
+  def dump_to_yaml_file(self, yaml_file_path):
     data = [word.to_dict() for word in self.words]
     with open(yaml_file_path, 'w') as h:
       yaml.dump(data, h, allow_unicode=True, default_flow_style=False)

--- a/chinesevocablist/models.py
+++ b/chinesevocablist/models.py
@@ -37,6 +37,12 @@ class Classifier:
       repr(self.simp),
       repr(self.pinyin),
     )
+  
+  def __eq__(self, other):
+    if not isinstance(other, Classifier):
+      raise TypeError('Cannot compare {} and {}'.format(self.__class__.__name__, other.__class__.__name__))
+
+    return self.trad == other.trad and self.simp == other.simp and self.pinyin == other.pinyin
 
 
 class ExampleSentence:
@@ -78,3 +84,10 @@ class ExampleSentence:
       pinyin=d.get('pinyin'),
       eng=d.get('eng'),
     )
+  
+  def __eq__(self, other):
+    if not isinstance(other, ExampleSentence):
+      raise TypeError('Cannot compare {} and {}'.format(self.__class__.__name__, other.__class__.__name__))
+
+    return (
+      self.trad == other.trad and self.simp == other.simp and self.pinyin == other.pinyin and self.eng == other.eng)

--- a/src/build_initial_list.py
+++ b/src/build_initial_list.py
@@ -5,6 +5,7 @@ from cedict import CedictWithPreferredEntries
 from example_sentences_list import ExampleSentenceList
 from hsk_list import HSKList
 from subtlex_list import LimitedSubtlexList
+from manual_edits import apply_manual_edits
 
 HSK_WEIGHT = 1
 SUBTLEX_WEIGHT = 1
@@ -71,6 +72,8 @@ def main():
 
   example_sentence_list = ExampleSentenceList.load()
   set_example_sentences(vocab_list, example_sentence_list)
+
+  apply_manual_edits(vocab_list)
 
   vocab_list.dump_to_yaml_file('/dev/stdout')
 

--- a/src/build_initial_list.py
+++ b/src/build_initial_list.py
@@ -72,7 +72,7 @@ def main():
   example_sentence_list = ExampleSentenceList.load()
   set_example_sentences(vocab_list, example_sentence_list)
 
-  vocab_list.dump_to_yaml('/dev/stdout')
+  vocab_list.dump_to_yaml_file('/dev/stdout')
 
 
 def set_example_sentences(vocab_list, example_sentences_list):

--- a/src/cedict.py
+++ b/src/cedict.py
@@ -182,7 +182,7 @@ class CedictWithPreferredEntries(Cedict):
   @staticmethod
   def load_preferred_entries_file(fpath):
     with open(fpath) as h:
-      return yaml.load(h)
+      return yaml.full_load(h)
 
   def pick_entry(self, simp=None, trad=None):
     if bool(simp) == bool(trad):

--- a/src/example_sentences_list.py
+++ b/src/example_sentences_list.py
@@ -15,7 +15,7 @@ def load_tatoeba_example_sentences_file(fpath):
   rv = []
 
   with open(fpath) as f:
-    data = yaml.load(f)
+    data = yaml.full_load(f)
     for item in data:
       rv.append(ExampleSentence(trad=item['trad'], simp=item['simp'], pinyin=item['pinyin'], eng=item['eng']))
 

--- a/src/generate_vocab_list_data.py
+++ b/src/generate_vocab_list_data.py
@@ -6,7 +6,7 @@ YAML parser, plus you don't have to convert from basic Python types into VocabWo
 """
 from chinesevocablist import VocabList
 
-vocab_list = VocabList.load_from_yaml('chinese_vocab_list.yaml')
+vocab_list = VocabList.load_from_yaml_file('chinese_vocab_list.yaml')
 
 print('from chinesevocablist import VocabList, VocabWord, ExampleSentence, Classifier')
 print('vocab_list = {}'.format(repr(vocab_list)))

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -122,7 +122,7 @@ def apply_manual_edits(vocab_list, manual_edits=None):
     If manual_edits is not passed, it will be computed from commit history using get_manual_edits.
     """
     if manual_edits is None:
-        manual_edits = get_manual_edits
+        manual_edits = get_manual_edits()
     
     for edit in manual_edits:
         edit.apply_to_vocab_word(vocab_list.trad_to_word[edit.trad])

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -113,3 +113,16 @@ def get_manual_edits():
                 trad_to_edit[edit.trad] = edit
     
     return list(trad_to_edit.values())
+
+
+def apply_manual_edits(vocab_list, manual_edits=None):
+    """
+    Apply manual_edits to a VocabList.
+
+    If manual_edits is not passed, it will be computed from commit history using get_manual_edits.
+    """
+    if manual_edits is None:
+        manual_edits = get_manual_edits
+    
+    for edit in manual_edits:
+        edit.apply_to_vocab_word(vocab_list.trad_to_word[edit.trad])

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -81,7 +81,7 @@ def get_manual_edits():
     """
     Go through commit history and find all manual edits.
 
-    Returns a dict mapping trad to ManualEdit.
+    Returns a list of ManualEdits.
     
     If there are multiple manual edits, they will be merged, with the later one taking priority.
     """
@@ -111,7 +111,5 @@ def get_manual_edits():
                 trad_to_edit[edit.trad] = trad_to_edit[edit.trad].merge(edit)
             else:
                 trad_to_edit[edit.trad] = edit
-
-        trad_to_edit.update({e.trad: e for e in edits})
     
-    return trad_to_edit
+    return list(trad_to_edit.values())

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -55,18 +55,24 @@ class ManualEdit:
             self.example_sentences)
     
     def to_dict(self):
+        example_sentences = None
+        if self.example_sentences is not None:
+            example_sentences = [es.to_dict() for es in self.example_sentences]
         return {
             'trad': self.trad,
             'defs': self.defs,
-            'example_sentences': [es.to_dict() for es in self.example_sentences],
+            'example_sentences': example_sentences,
         }
     
     @classmethod
     def from_dict(cls, d):
+        example_sentences = None
+        if d['example_sentences'] is not None:
+            example_sentences=[ExampleSentence.from_dict(es_d) for es_d in d['example_sentences']]
         return cls(
             trad=d['trad'],
             defs=d['defs'],
-            example_sentences=[ExampleSentence.from_dict(es_d) for es_d in d['example_sentences']])
+            example_sentences=example_sentences)
 
 
 def _get_manual_edits_for_commit(commit):

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -6,7 +6,7 @@ _VOCAB_LIST_FILE = 'chinese_vocab_list.yaml'
 
 
 class ManualEdit:
-    def __init__(trad, defs=None, example_sentences=None):
+    def __init__(self, trad, defs=None, example_sentences=None):
         """
         Set defs to update defs, or leave as None to use default defs. Same for example_sentences.
 
@@ -42,21 +42,27 @@ class ManualEdit:
             example_sentences=other.example_sentences if other.example_sentences is not None
                               else self.example_sentences)
 
+    def __repr__(self):
+        return '{}({}, defs={}, example_sentences={})'.format(
+            self.__class__.__name__,
+            self.trad,
+            self.defs,
+            self.example_sentences)
 
 def _get_manual_edits_for_commit(commit):
     # Note: This is slow. We could cache the result if it becomes a problem.
     before_list = VocabList.load_from_yaml_str(
         subprocess.check_output([
-            'git'
+            'git',
             'show',
             '{}^:chinese_vocab_list.yaml'.format(commit),
         ]).decode('utf8')
     )
     after_list = VocabList.load_from_yaml_str(
         subprocess.check_output([
-            'git'
+            'git',
             'show',
-            '{}^:chinese_vocab_list.yaml'.format(commit),
+            '{}:chinese_vocab_list.yaml'.format(commit),
         ]).decode('utf8')
     )
 

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -146,7 +146,7 @@ def get_manual_edits():
                 file=sys.stderr)
             manual_edit_cache[commit] = _get_manual_edits_for_commit(commit)
 
-        edits = _get_manual_edits_for_commit(commit)
+        edits = manual_edit_cache[commit]
 
         for edit in edits:
             if edit.trad in trad_to_edit:

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -1,3 +1,10 @@
+import subprocess
+from chinesevocablist import VocabList
+
+_MANUAL_EDIT_START = '521b4741b8e135642c131350462cfb020a3ef1f3'  # last commit before we started doing manual edits
+_VOCAB_LIST_FILE = 'chinese_vocab_list.yaml'
+
+
 class ManualEdit:
     def __init__(trad, defs=None, example_sentences=None):
         """
@@ -21,3 +28,84 @@ class ManualEdit:
         
         if self.example_sentences is not None:
             vocab_word.example_sentences = self.example_sentences
+    
+    def merge(self, other):
+        """
+        Merges self with other. If a field is set in both self and other, will use other's version of that field.
+        """
+        if self.trad != other.trad:
+            raise RuntimeError('Passed wrong ManualEdit to ManualEdit.merge')
+        
+        return ManualEdit(
+            self.trad,
+            defs=other.defs if other.defs is not None else self.defs,
+            example_sentences=other.example_sentences if other.example_sentences is not None
+                              else self.example_sentences)
+
+
+def _get_manual_edits_for_commit(commit):
+    # Note: This is slow. We could cache the result if it becomes a problem.
+    before_list = VocabList.load_from_yaml_str(
+        subprocess.check_output([
+            'git'
+            'show',
+            '{}^:chinese_vocab_list.yaml'.format(commit),
+        ]).decode('utf8')
+    )
+    after_list = VocabList.load_from_yaml_str(
+        subprocess.check_output([
+            'git'
+            'show',
+            '{}^:chinese_vocab_list.yaml'.format(commit),
+        ]).decode('utf8')
+    )
+
+    ret = []
+    for new_word in after_list.words:
+        old_word = before_list.trad_to_word[new_word.trad]
+        new_defs = new_word.defs if new_word.defs != old_word.defs else None
+        new_sents = new_word.example_sentences if new_word.example_sentences != old_word.example_sentences else None
+        if new_defs is not None or new_sents is not None:
+            ret.append(ManualEdit(new_word.trad, defs=new_defs, example_sentences=new_sents))
+    
+    return ret
+
+
+def get_manual_edits():
+    """
+    Go through commit history and find all manual edits.
+
+    Returns a dict mapping trad to ManualEdit.
+    
+    If there are multiple manual edits, they will be merged, with the later one taking priority.
+    """
+    commits = subprocess.check_output([
+        'git',
+        'log',
+        '--pretty=format:%H',
+        '{}..HEAD'.format(_MANUAL_EDIT_START),
+    ]).decode('utf8').splitlines()
+
+    trad_to_edit = {}
+    for commit in commits:
+        changed_files = subprocess.check_output([
+            'git',
+            'diff-tree',
+            '--no-commit-id',
+            '--name-only',
+            '-r', commit,
+        ]).decode('utf8').splitlines()
+        
+        if changed_files != [_VOCAB_LIST_FILE]:
+            continue
+        
+        edits = _get_manual_edits_for_commit(commit)
+        for edit in edits:
+            if edit.trad in trad_to_edit:
+                trad_to_edit[edit.trad] = trad_to_edit[edit.trad].merge(edit)
+            else:
+                trad_to_edit[edit.trad] = edit
+
+        trad_to_edit.update({e.trad: e for e in edits})
+    
+    return trad_to_edit

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -1,11 +1,11 @@
 class ManualEdit:
-    def __init__(simp, defs=None, example_sentences=None):
+    def __init__(trad, defs=None, example_sentences=None):
         """
         Set defs to update defs, or leave as None to use default defs. Same for example_sentences.
 
         Changing other fields, or adjusting rank, via manual edit is not supported.
         """
-        self.simp = simp
+        self.trad = trad
         self.defs = defs
         self.example_sentences = example_sentences
     
@@ -13,7 +13,7 @@ class ManualEdit:
         """
         Changes vocab_word in-place according to this ManualEdit.
         """
-        if vocab_word.simp != self.simp:
+        if vocab_word.trad != self.trad:
             raise RuntimeError('Passed wrong VocabWord to ManualEdit.apply_to_vocab_word')
         
         if self.defs is not None:

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -111,12 +111,12 @@ def get_manual_edits():
     
     If there are multiple manual edits, they will be merged, with the later one taking priority.
     """
-    commits = subprocess.check_output([
+    commits = list(reversed(subprocess.check_output([
         'git',
         'log',
         '--pretty=format:%H',
         '{}..HEAD'.format(_MANUAL_EDIT_START),
-    ]).decode('utf8').splitlines()
+    ]).decode('utf8').splitlines()))
 
     # manual_edit_cache is a dict of commit str -> list of manual edits
     if os.path.exists(_MANUAL_EDIT_CACHE_PATH):

--- a/src/manual_edits.py
+++ b/src/manual_edits.py
@@ -1,0 +1,23 @@
+class ManualEdit:
+    def __init__(simp, defs=None, example_sentences=None):
+        """
+        Set defs to update defs, or leave as None to use default defs. Same for example_sentences.
+
+        Changing other fields, or adjusting rank, via manual edit is not supported.
+        """
+        self.simp = simp
+        self.defs = defs
+        self.example_sentences = example_sentences
+    
+    def apply_to_vocab_word(self, vocab_word):
+        """
+        Changes vocab_word in-place according to this ManualEdit.
+        """
+        if vocab_word.simp != self.simp:
+            raise RuntimeError('Passed wrong VocabWord to ManualEdit.apply_to_vocab_word')
+        
+        if self.defs is not None:
+            vocab_word.defs = self.defs
+        
+        if self.example_sentences is not None:
+            vocab_word.example_sentences = self.example_sentences

--- a/src/subtlex_list.py
+++ b/src/subtlex_list.py
@@ -190,7 +190,7 @@ class DedupedSubtlexList(FilteredSubtlexList):
   @staticmethod
   def load_dupes_file(fpath):
     with open(fpath) as h:
-      return yaml.load(h)
+      return yaml.full_load(h)
 
   def __init__(self, words, cedict, dupes):
     super().__init__(words, cedict)


### PR DESCRIPTION
Allow manual edits, which are commits where the definitions and/or example sentences for a word in `chinese_vocab_list.yaml` are changed manually, without any changes to the Python code or `reference_files`/`contrib_files` that are used to generate `chinese_vocab_list.yaml`.

A commit is considered a manual edit if it only changes `chinese_vocab_list.yaml` and nothing else.

When you run `make chinese_vocab_list.yaml`, it searches through Git history and finds manual edits, and applies them when generating the list. Newer edits override older edits.

Once the definitions or example sentences are edited, they will never be regenerated automatically, even if `reference_files`/`contrib_files` are updated. This applies separately to definitions and example sentences; e.g. you can manually edit the definitions, and the example sentences will still be automatically generated.